### PR TITLE
fix: add account tags to metrics where unsupported service

### DIFF
--- a/main.go
+++ b/main.go
@@ -374,6 +374,7 @@ func (e *RecordEnhancer) enhanceRecordData(
 							svc := config.SupportedServices.GetService(cwm.Namespace)
 							if svc == nil {
 								e.logger.Debug("Unsupported namespace, skipping tags enrichment", "namespace", cwm.Namespace, "metric", cwm.MetricName)
+								e.addAccountTagsToMetric(dp, yaceCWM, e.awsAccountToTagsMap)
 								continue
 							}
 


### PR DESCRIPTION
Forgot something in last PR. The list of AWS services supported by YACE are [here](https://github.com/prometheus-community/yet-another-cloudwatch-exporter/tree/master) but AWS/EKS is not listed as supported so the code continues before executing e.addAccountTagsToMetric(dp, yaceCWM, e.awsAccountToTagsMap) for this code path.

This PR adds the extra execution.

Also realized we're on an old version of YACE v0.56.0 from Jan 2024. The above link is the latest, and AWS/EKS is still not supported, but we should probably upgrade to the latest version. The old version was when the repo was owned by NerdsWords, and now it has been taken over by the Prometheus community.