### PR TITLE
fix: only re-write TimeUnixNano timestamp

### DIFF
--- a/main.go
+++ b/main.go
@@ -383,7 +383,7 @@ func (e *RecordEnhancer) enhanceRecordData(
 								if _, ok := e.metricsToRewriteTimestamp[key]; ok {
 									currentTimeNano := time.Now().UnixNano()
 									dp.TimeUnixNano = uint64(currentTimeNano)
-									// According to Chronosphere only the timestamp needs to be updated for the staleness to be reset.
+									// According to Chronosphere only the TimeUnixNano timestamp needs to be updated for the staleness to be reset.
 									// dp.StartTimeUnixNano = uint64(currentTimeNano - time.Minute.Nanoseconds())
 								}
 							}


### PR DESCRIPTION
According to Chronosphere, only the `TimeUnixNano` timestamp needs to be updated for the staleness to be reset.